### PR TITLE
resume order after 20% video hits/plays

### DIFF
--- a/app/src/main/java/online/cagocapps/calvinsstupidapp/MainActivity.java
+++ b/app/src/main/java/online/cagocapps/calvinsstupidapp/MainActivity.java
@@ -15,6 +15,7 @@ import android.widget.VideoView;
 public class MainActivity extends AppCompatActivity {
     private VideoView videoView;
     private int i = 1; //(int)(Math.random() *5+1);
+    private int prev = 1;
     private String path;
     private Button button;
     private Long length;
@@ -44,7 +45,9 @@ public class MainActivity extends AppCompatActivity {
 
     public void playVideo(View view) {
         int l = (int) (Math.random()* 5 +1);
-        if ( l == 5 ) i = l;
+        if ( l == 5 ){
+            prev = i;
+            i = l;
         if (!videoView.isPlaying()) {
             if (i == 1) {
                 path = "android.resource://" + getPackageName() + "/" + R.raw.donteatme;
@@ -61,6 +64,7 @@ public class MainActivity extends AppCompatActivity {
             } else if (i == 5) {
                 path = "android.resource://" + getPackageName() + "/" + R.raw.silentnight;
                 length = (long) 115000;
+                i = prev;
             }
             MediaController mc = new MediaController(videoView.getContext());
             mc.setAnchorView(videoView);


### PR DESCRIPTION
Before this change, if the 20% chance hits, it would play silent night, then i would be set back to 1. This fix plays silent night, then sets i back to whatever it was before (as it was already incremented after the previous video played), so the sequence continues on the next tap.